### PR TITLE
require ssdtools version 1.0.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ URL: https://github.com/bcgov/shinyssdtools
 BugReports: https://github.com/bcgov/shinyssdtools/issues
 Depends: 
     R (>= 3.5),
-    ssdtools
+    ssdtools (>= 1.0.1)
 Imports:
     dplyr,
     DT,


### PR DESCRIPTION
Ensures that ssdtools version 1.0.1 is installed prior to installing shinyssdtools

